### PR TITLE
AWS DNS record creation

### DIFF
--- a/cmd/ingress-controller/main.go
+++ b/cmd/ingress-controller/main.go
@@ -17,7 +17,7 @@ const numThreads = 2
 var kubeconfig = flag.String("kubeconfig", "", "Path to kubeconfig")
 var kubecontext = flag.String("context", "", "Context to use in the Kubeconfig file, instead of the current context")
 
-var domain = flag.String("domain", "kcp-apps.127.0.0.1.nip.io", "The domain to use to expose ingresses")
+var domain = flag.String("domain", "hcpapps.net", "The domain to use to expose ingresses")
 
 var envoyEnableXDS = flag.Bool("envoyxds", false, "Start an Envoy control plane")
 var envoyXDSPort = flag.Uint("envoyxds-port", 18000, "Envoy control plane port")
@@ -51,5 +51,9 @@ func main() {
 	go func() {
 		ingress.NewController(controllerConfig).Start(numThreads)
 	}()
-	dns.NewController(&dns.ControllerConfig{Cfg: r}).Start(numThreads)
+	c, err := dns.NewController(&dns.ControllerConfig{Cfg: r})
+	if err != nil {
+		klog.Fatal(err)
+	}
+	c.Start(numThreads)
 }

--- a/cmd/ingress-controller/main.go
+++ b/cmd/ingress-controller/main.go
@@ -18,6 +18,7 @@ var kubeconfig = flag.String("kubeconfig", "", "Path to kubeconfig")
 var kubecontext = flag.String("context", "", "Context to use in the Kubeconfig file, instead of the current context")
 
 var domain = flag.String("domain", "hcpapps.net", "The domain to use to expose ingresses")
+var dnsProvider = flag.String("dns-provider", "aws", "The DNS provider being used [aws, fake]")
 
 var envoyEnableXDS = flag.Bool("envoyxds", false, "Start an Envoy control plane")
 var envoyXDSPort = flag.Uint("envoyxds-port", 18000, "Envoy control plane port")
@@ -51,7 +52,7 @@ func main() {
 	go func() {
 		ingress.NewController(controllerConfig).Start(numThreads)
 	}()
-	c, err := dns.NewController(&dns.ControllerConfig{Cfg: r})
+	c, err := dns.NewController(&dns.ControllerConfig{Cfg: r, DNSProvider: dnsProvider})
 	if err != nil {
 		klog.Fatal(err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -3,9 +3,11 @@ module github.com/kuadrant/kcp-ingress
 go 1.16
 
 require (
+	github.com/aws/aws-sdk-go v1.38.49
 	github.com/envoyproxy/go-control-plane v0.10.1
 	github.com/envoyproxy/protoc-gen-validate v0.6.1 // indirect
 	github.com/go-logr/logr v1.1.0 // indirect
+	github.com/google/go-cmp v0.5.6
 	github.com/google/uuid v1.3.0
 	github.com/imdario/mergo v0.3.9 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
@@ -26,26 +28,7 @@ replace (
 	k8s.io/apiextensions-apiserver => github.com/kcp-dev/kubernetes/staging/src/k8s.io/apiextensions-apiserver v0.0.0-20210921141446-281309ebaa64
 	k8s.io/apimachinery => github.com/kcp-dev/kubernetes/staging/src/k8s.io/apimachinery v0.0.0-20210921141446-281309ebaa64
 	k8s.io/apiserver => github.com/kcp-dev/kubernetes/staging/src/k8s.io/apiserver v0.0.0-20210921141446-281309ebaa64
-	k8s.io/cli-runtime => github.com/kcp-dev/kubernetes/staging/src/k8s.io/cli-runtime v0.0.0-20210921141446-281309ebaa64
 	k8s.io/client-go => github.com/kcp-dev/kubernetes/staging/src/k8s.io/client-go v0.0.0-20210921141446-281309ebaa64
-	k8s.io/cloud-provider => github.com/kcp-dev/kubernetes/staging/src/k8s.io/cloud-provider v0.0.0-20210921141446-281309ebaa64
-	k8s.io/cluster-bootstrap => github.com/kcp-dev/kubernetes/staging/src/k8s.io/cluster-bootstrap v0.0.0-20210921141446-281309ebaa64
 	k8s.io/code-generator => github.com/kcp-dev/kubernetes/staging/src/k8s.io/code-generator v0.0.0-20210921141446-281309ebaa64
 	k8s.io/component-base => github.com/kcp-dev/kubernetes/staging/src/k8s.io/component-base v0.0.0-20210921141446-281309ebaa64
-	k8s.io/component-helpers => github.com/kcp-dev/kubernetes/staging/src/k8s.io/component-helpers v0.0.0-20210921141446-281309ebaa64
-	k8s.io/controller-manager => github.com/kcp-dev/kubernetes/staging/src/k8s.io/controller-manager v0.0.0-20210921141446-281309ebaa64
-	k8s.io/cri-api => github.com/kcp-dev/kubernetes/staging/src/k8s.io/cri-api v0.0.0-20210921141446-281309ebaa64
-	k8s.io/csi-translation-lib => github.com/kcp-dev/kubernetes/staging/src/k8s.io/csi-translation-lib v0.0.0-20210921141446-281309ebaa64
-	k8s.io/kube-aggregator => github.com/kcp-dev/kubernetes/staging/src/k8s.io/kube-aggregator v0.0.0-20210921141446-281309ebaa64
-	k8s.io/kube-controller-manager => github.com/kcp-dev/kubernetes/staging/src/k8s.io/kube-controller-manager v0.0.0-20210921141446-281309ebaa64
-	k8s.io/kube-proxy => github.com/kcp-dev/kubernetes/staging/src/k8s.io/kube-proxy v0.0.0-20210921141446-281309ebaa64
-	k8s.io/kube-scheduler => github.com/kcp-dev/kubernetes/staging/src/k8s.io/kube-scheduler v0.0.0-20210921141446-281309ebaa64
-	k8s.io/kubectl => github.com/kcp-dev/kubernetes/staging/src/k8s.io/kubectl v0.0.0-20210921141446-281309ebaa64
-	k8s.io/kubelet => github.com/kcp-dev/kubernetes/staging/src/k8s.io/kubelet v0.0.0-20210921141446-281309ebaa64
-	k8s.io/kubernetes => github.com/kcp-dev/kubernetes v0.0.0-20210921141446-281309ebaa64
-	k8s.io/legacy-cloud-providers => github.com/kcp-dev/kubernetes/staging/src/k8s.io/legacy-cloud-providers v0.0.0-20210921141446-281309ebaa64
-	k8s.io/metrics => github.com/kcp-dev/kubernetes/staging/src/k8s.io/metrics v0.0.0-20210921141446-281309ebaa64
-	k8s.io/mount-utils => github.com/kcp-dev/kubernetes/staging/src/k8s.io/mount-utils v0.0.0-20210921141446-281309ebaa64
-	k8s.io/pod-security-admission => github.com/kcp-dev/kubernetes/staging/src/k8s.io/pod-security-admission v0.0.0-20210921141446-281309ebaa64
-	k8s.io/sample-apiserver => github.com/kcp-dev/kubernetes/staging/src/k8s.io/sample-apiserver v0.0.0-20210921141446-281309ebaa64
 )

--- a/go.sum
+++ b/go.sum
@@ -80,6 +80,8 @@ github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hC
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
+github.com/aws/aws-sdk-go v1.38.49 h1:E31vxjCe6a5I+mJLmUGaZobiWmg9KdWaud9IfceYeYQ=
+github.com/aws/aws-sdk-go v1.38.49/go.mod h1:hcU610XS61/+aQV88ixoOzUoG7v3b31pl2zKMmprdro=
 github.com/benbjohnson/clock v1.0.3/go.mod h1:bGMdMPoPVvcYyt1gHDf4J2KE153Yf9BuiUKYMaxlTDM=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
@@ -354,6 +356,10 @@ github.com/jcmturner/goidentity/v6 v6.0.1/go.mod h1:X1YW3bgtvwAXju7V3LCIMpY0Gbxy
 github.com/jcmturner/gokrb5/v8 v8.4.2/go.mod h1:sb+Xq/fTY5yktf/VxLsE3wlfPqQjp0aWNYyvBVK62bc=
 github.com/jcmturner/rpc/v2 v2.0.3/go.mod h1:VUJYCIDm3PVOEHw8sgt091/20OJjskO/YJki3ELg/Hc=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
+github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=
+github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
+github.com/jmespath/go-jmespath/internal/testify v1.5.1 h1:shLQSRRSCCPj3f2gpwzGwWFoC7ycTf1rcQZHOlsJ6N8=
+github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
 github.com/jonboulle/clockwork v0.2.2/go.mod h1:Pkfl5aHPm1nk2H9h0bjmnJD/BcgbGXUBGnn1kMkgxc8=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=

--- a/pkg/dns/aws/dns.go
+++ b/pkg/dns/aws/dns.go
@@ -1,0 +1,172 @@
+package aws
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/kuadrant/kcp-ingress/pkg/apis/kuadrant/v1"
+	"github.com/kuadrant/kcp-ingress/pkg/dns"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/aws/endpoints"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/route53"
+
+	kerrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/klog"
+)
+
+const (
+	// chinaRoute53Endpoint is the Route 53 service endpoint used for AWS China regions.
+	chinaRoute53Endpoint = "https://route53.amazonaws.com.cn"
+)
+
+var (
+	_ dns.Provider = &Provider{}
+)
+
+// Inspired by https://github.com/openshift/cluster-ingress-operator/blob/master/pkg/dns/aws/dns.go
+type Provider struct {
+	route53 *route53.Route53
+	config  Config
+}
+
+// Config is the necessary input to configure the manager.
+type Config struct {
+	// Region is the AWS region ELBs are created in.
+	Region string
+}
+
+func NewProvider(config Config) (*Provider, error) {
+	var region string
+	if len(config.Region) > 0 {
+		region = config.Region
+		klog.Infof("using region from operator config region name %s", region)
+	}
+
+	sess, err := session.NewSession(&aws.Config{Region: aws.String(region)})
+	if err != nil {
+		return nil, fmt.Errorf("couldn't create AWS client session: %v", err)
+	}
+
+	r53Config := aws.NewConfig()
+
+	// If the region is in aws china, cn-north-1 or cn-northwest-1, we should:
+	// 1. hard code route53 api endpoint to https://route53.amazonaws.com.cn and region to "cn-northwest-1"
+	//    as route53 is not GA in AWS China and aws sdk didn't have the endpoint.
+	// 2. use the aws china region cn-northwest-1 to setup tagging api correctly instead of "us-east-1"
+	switch region {
+	case endpoints.CnNorth1RegionID, endpoints.CnNorthwest1RegionID:
+		r53Config = r53Config.WithRegion(endpoints.CnNorthwest1RegionID).WithEndpoint(chinaRoute53Endpoint)
+	case endpoints.UsGovEast1RegionID, endpoints.UsGovWest1RegionID:
+		// Route53 for GovCloud uses the "us-gov-west-1" region id:
+		// https://docs.aws.amazon.com/govcloud-us/latest/UserGuide/using-govcloud-endpoints.html
+		r53Config = r53Config.WithRegion(endpoints.UsGovWest1RegionID)
+	case endpoints.UsIsoEast1RegionID:
+		// Do not override the region in C2s
+		r53Config = r53Config.WithRegion(region)
+	default:
+		// Use us-east-1 for Route 53 in AWS Regions other than China or GovCloud Regions.
+		// See https://docs.aws.amazon.com/general/latest/gr/r53.html for details.
+		r53Config = r53Config.WithRegion(endpoints.UsEast1RegionID)
+	}
+	p := &Provider{
+		route53: route53.New(sess, r53Config),
+		config:  config,
+	}
+	if err := validateServiceEndpoints(p); err != nil {
+		return nil, fmt.Errorf("failed to validate aws provider service endpoints: %v", err)
+	}
+	return p, nil
+}
+
+// validateServiceEndpoints validates that provider clients can communicate with
+// associated API endpoints by having each client make a list/describe/get call.
+func validateServiceEndpoints(provider *Provider) error {
+	var errs []error
+	zoneInput := route53.ListHostedZonesInput{MaxItems: aws.String("1")}
+	if _, err := provider.route53.ListHostedZones(&zoneInput); err != nil {
+		errs = append(errs, fmt.Errorf("failed to list route53 hosted zones: %v", err))
+	}
+	return kerrors.NewAggregate(errs)
+}
+
+type action string
+
+const (
+	upsertAction action = "UPSERT"
+	deleteAction action = "DELETE"
+)
+
+func (m *Provider) Ensure(record *v1.DNSRecord, zone v1.DNSZone) error {
+	return m.change(record, zone, upsertAction)
+}
+
+func (m *Provider) Delete(record *v1.DNSRecord, zone v1.DNSZone) error {
+	return m.change(record, zone, deleteAction)
+}
+
+// change will perform an action on a record.
+func (m *Provider) change(record *v1.DNSRecord, zone v1.DNSZone, action action) error {
+	if record.Spec.RecordType != v1.ARecordType {
+		return fmt.Errorf("unsupported record type %s", record.Spec.RecordType)
+	}
+	domain, targets := record.Spec.DNSName, record.Spec.Targets
+	if len(domain) == 0 {
+		return fmt.Errorf("domain is required")
+	}
+	if len(targets) == 0 {
+		return fmt.Errorf("targets is required")
+	}
+
+	// Configure records.
+	err := m.updateRecord(domain, zone.ID, string(action), targets, record.Spec.RecordTTL)
+	if err != nil {
+		return fmt.Errorf("failed to update alias in zone %s: %v", zone.ID, err)
+	}
+	switch action {
+	case upsertAction:
+		klog.Infof("upserted DNS record %v, zone %v", record.Spec, zone)
+	case deleteAction:
+		klog.Infof("deleted DNS record %v, zone %v", record.Spec, zone)
+	}
+	return nil
+}
+
+func (m *Provider) updateRecord(domain, zoneID, action string, targets []string, ttl int64) error {
+	input := route53.ChangeResourceRecordSetsInput{HostedZoneId: aws.String(zoneID)}
+
+	var resourceRecords []*route53.ResourceRecord
+	for _, target := range targets {
+		resourceRecords = append(resourceRecords, &route53.ResourceRecord{Value: aws.String(target)})
+	}
+
+	input.ChangeBatch = &route53.ChangeBatch{
+		Changes: []*route53.Change{
+			{
+				Action: aws.String(action),
+				ResourceRecordSet: &route53.ResourceRecordSet{
+					Name:            aws.String(domain),
+					Type:            aws.String(route53.RRTypeA),
+					TTL:             aws.Int64(ttl),
+					ResourceRecords: resourceRecords,
+				},
+			},
+		},
+	}
+	resp, err := m.route53.ChangeResourceRecordSets(&input)
+	if err != nil {
+		if action == string(deleteAction) {
+			if aerr, ok := err.(awserr.Error); ok {
+				if strings.Contains(aerr.Message(), "not found") {
+					klog.Infof("record not found: zone id: %s, domain: %s, targets: %s", zoneID, domain, targets)
+					return nil
+				}
+			}
+		}
+		return fmt.Errorf("couldn't update DNS record in zone %s: %v", zoneID, err)
+	}
+	klog.Infof("updated DNS record: zone id: %s, domain: %s, targets: %s, resp: %v", zoneID, domain, targets, resp)
+	return nil
+}

--- a/pkg/dns/dns.go
+++ b/pkg/dns/dns.go
@@ -1,0 +1,21 @@
+package dns
+
+import (
+	v1 "github.com/kuadrant/kcp-ingress/pkg/apis/kuadrant/v1"
+)
+
+// Provider knows how to manage DNS zones only as pertains to routing.
+type Provider interface {
+	// Ensure will create or update record.
+	Ensure(record *v1.DNSRecord, zone v1.DNSZone) error
+
+	// Delete will delete record.
+	Delete(record *v1.DNSRecord, zone v1.DNSZone) error
+}
+
+var _ Provider = &FakeProvider{}
+
+type FakeProvider struct{}
+
+func (_ *FakeProvider) Ensure(record *v1.DNSRecord, zone v1.DNSZone) error { return nil }
+func (_ *FakeProvider) Delete(record *v1.DNSRecord, zone v1.DNSZone) error { return nil }

--- a/pkg/reconciler/dns/controller.go
+++ b/pkg/reconciler/dns/controller.go
@@ -37,7 +37,7 @@ func NewController(config *ControllerConfig) (*Controller, error) {
 		stopCh: stopCh,
 	}
 
-	dnsProvider, err := newAWSDNSProvider()
+	dnsProvider, err := createDNSProvider(*config.DNSProvider)
 	if err != nil {
 		return nil, err
 	}
@@ -79,7 +79,8 @@ func NewController(config *ControllerConfig) (*Controller, error) {
 }
 
 type ControllerConfig struct {
-	Cfg *rest.Config
+	Cfg         *rest.Config
+	DNSProvider *string
 }
 
 type Controller struct {
@@ -181,6 +182,20 @@ func (c *Controller) process(key string) error {
 	}
 
 	return err
+}
+
+func createDNSProvider(dnsProviderName string) (dns.Provider, error) {
+	var dnsProvider dns.Provider
+	var dnsError error
+	switch dnsProviderName {
+	case "aws":
+		klog.Infof("Using aws dns provider")
+		dnsProvider, dnsError = newAWSDNSProvider()
+	default:
+		klog.Infof("Using fake dns provider")
+		dnsProvider = &dns.FakeProvider{}
+	}
+	return dnsProvider, dnsError
 }
 
 func newAWSDNSProvider() (dns.Provider, error) {

--- a/pkg/reconciler/dns/controller.go
+++ b/pkg/reconciler/dns/controller.go
@@ -176,11 +176,7 @@ func (c *Controller) process(key string) error {
 
 	// If the object being reconciled changed as a result, update it.
 	if !equality.Semantic.DeepEqual(previous, current) {
-		_, uerr := c.client.KuadrantV1().DNSRecords(current.Namespace).UpdateStatus(ctx, current, metav1.UpdateOptions{})
-		if uerr != nil {
-			return uerr
-		}
-		_, uerr = c.client.KuadrantV1().DNSRecords(current.Namespace).Update(ctx, current, metav1.UpdateOptions{})
+		_, uerr := c.client.KuadrantV1().DNSRecords(current.Namespace).Update(ctx, current, metav1.UpdateOptions{})
 		return uerr
 	}
 

--- a/pkg/reconciler/dns/dns_record.go
+++ b/pkg/reconciler/dns/dns_record.go
@@ -2,15 +2,222 @@ package dns
 
 import (
 	"context"
+	"fmt"
+	"reflect"
 
-	v1 "github.com/kuadrant/kcp-ingress/pkg/apis/kuadrant/v1"
+	"github.com/kuadrant/kcp-ingress/pkg/apis/kuadrant/v1"
+	"github.com/kuadrant/kcp-ingress/pkg/util/slice"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilclock "k8s.io/apimachinery/pkg/util/clock"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/klog"
+)
+
+type ConditionStatus string
+
+const (
+	DNSRecordFinalizer = "kuadrant.dev/dns-record"
+
+	ConditionTrue    ConditionStatus = "True"
+	ConditionFalse   ConditionStatus = "False"
+	ConditionUnknown ConditionStatus = "Unknown"
 )
 
 func (c *Controller) reconcile(ctx context.Context, dnsRecord *v1.DNSRecord) error {
 	klog.Infof("reconciling DNSRecord %q", dnsRecord.Name)
 
-	// TODO: Reconcile record to DNS server
+	// If the DNS record was deleted, clean up and return.
+	if dnsRecord.DeletionTimestamp != nil && !dnsRecord.DeletionTimestamp.IsZero() {
+		klog.Infof("deleting dns record %v", dnsRecord)
+		if err := c.deleteRecord(dnsRecord); err != nil {
+			klog.Error(err, "failed to delete dnsrecord; will retry", "dnsrecord", dnsRecord)
+			return err
+		}
+		return nil
+	}
 
+	if !slice.ContainsString(dnsRecord.Finalizers, DNSRecordFinalizer) {
+		dnsRecord.Finalizers = append(dnsRecord.Finalizers, DNSRecordFinalizer)
+	}
+
+	statuses := c.publishRecordToZones(c.dnsZones, dnsRecord)
+	if !dnsZoneStatusSlicesEqual(statuses, dnsRecord.Status.Zones) {
+		dnsRecord.Status.Zones = statuses
+		dnsRecord.Status.ObservedGeneration = dnsRecord.Generation
+	}
 	return nil
+}
+
+func (r *Controller) publishRecordToZones(zones []v1.DNSZone, record *v1.DNSRecord) []v1.DNSZoneStatus {
+	var statuses []v1.DNSZoneStatus
+	for i := range zones {
+		zone := zones[i]
+
+		// Only publish the record if the DNSRecord has been modified
+		// (which would mean the target could have changed) or its
+		// status does not indicate that it has already been published.
+		if record.Generation == record.Status.ObservedGeneration && recordIsAlreadyPublishedToZone(record, &zone) {
+			klog.Info("skipping zone to which the DNS record is already published", "record", record.Spec, "dnszone", zone)
+			continue
+		}
+
+		condition := v1.DNSZoneCondition{
+			Status:             string(ConditionUnknown),
+			Type:               v1.DNSRecordFailedConditionType,
+			LastTransitionTime: metav1.Now(),
+		}
+
+		if recordIsAlreadyPublishedToZone(record, &zone) {
+			klog.Info("replacing DNS record", "record", record.Spec, "dnszone", zone)
+
+			if err := r.dnsProvider.Ensure(record, zone); err != nil {
+				klog.Error(err, "failed to replace DNS record in zone", "record", record.Spec, "dnszone", zone)
+				condition.Status = string(ConditionTrue)
+				condition.Reason = "ProviderError"
+				condition.Message = fmt.Sprintf("The DNS provider failed to replace the record: %v", err)
+			} else {
+				klog.Info("replaced DNS record in zone", "record", record.Spec, "dnszone", zone)
+				condition.Status = string(ConditionFalse)
+				condition.Reason = "ProviderSuccess"
+				condition.Message = "The DNS provider succeeded in replacing the record"
+			}
+		} else {
+			if err := r.dnsProvider.Ensure(record, zone); err != nil {
+				klog.Error(err, "failed to publish DNS record to zone", "record", record.Spec, "dnszone", zone)
+				condition.Status = string(ConditionTrue)
+				condition.Reason = "ProviderError"
+				condition.Message = fmt.Sprintf("The DNS provider failed to ensure the record: %v", err)
+			} else {
+				klog.Info("published DNS record to zone", "record", record.Spec, "dnszone", zone)
+				condition.Status = string(ConditionFalse)
+				condition.Reason = "ProviderSuccess"
+				condition.Message = "The DNS provider succeeded in ensuring the record"
+			}
+		}
+		statuses = append(statuses, v1.DNSZoneStatus{
+			DNSZone:    zone,
+			Conditions: []v1.DNSZoneCondition{condition},
+		})
+	}
+	return mergeStatuses(zones, record.Status.DeepCopy().Zones, statuses)
+}
+
+func (r *Controller) deleteRecord(record *v1.DNSRecord) error {
+	var errs []error
+	for i := range record.Status.Zones {
+		zone := record.Status.Zones[i].DNSZone
+		// If the record is currently not published in a zone,
+		// skip deleting it for that zone.
+		if !recordIsAlreadyPublishedToZone(record, &zone) {
+			continue
+		}
+		err := r.dnsProvider.Delete(record, zone)
+		if err != nil {
+			errs = append(errs, err)
+		} else {
+			klog.Info("deleted dnsrecord from DNS provider", "record", record.Spec, "zone", zone)
+		}
+	}
+	if len(errs) == 0 {
+		if slice.ContainsString(record.Finalizers, DNSRecordFinalizer) {
+			record.Finalizers = slice.RemoveString(record.Finalizers, DNSRecordFinalizer)
+		}
+	}
+	return utilerrors.NewAggregate(errs)
+}
+
+// recordIsAlreadyPublishedToZone returns a Boolean value indicating whether the
+// given DNSRecord is already published to the given zone, as determined from
+// the DNSRecord's status conditions.
+func recordIsAlreadyPublishedToZone(record *v1.DNSRecord, zoneToPublish *v1.DNSZone) bool {
+	for _, zoneInStatus := range record.Status.Zones {
+		if !reflect.DeepEqual(&zoneInStatus.DNSZone, zoneToPublish) {
+			continue
+		}
+
+		for _, condition := range zoneInStatus.Conditions {
+			if condition.Type == v1.DNSRecordFailedConditionType {
+				return condition.Status == string(ConditionFalse)
+			}
+		}
+	}
+
+	return false
+}
+
+// mergeStatuses updates or extends the provided slice of statuses with the
+// provided updates and returns the resulting slice.
+func mergeStatuses(zones []v1.DNSZone, statuses, updates []v1.DNSZoneStatus) []v1.DNSZoneStatus {
+	var additions []v1.DNSZoneStatus
+	for i, update := range updates {
+		add := true
+		for j, status := range statuses {
+			if cmp.Equal(status.DNSZone, update.DNSZone) {
+				add = false
+				statuses[j].Conditions = mergeConditions(status.Conditions, update.Conditions)
+			}
+		}
+		if add {
+			additions = append(additions, updates[i])
+		}
+	}
+	return append(statuses, additions...)
+}
+
+// clock is to enable unit testing
+var clock utilclock.Clock = utilclock.RealClock{}
+
+// mergeConditions adds or updates matching conditions, and updates
+// the transition time if details of a condition have changed. Returns
+// the updated condition array.
+func mergeConditions(conditions, updates []v1.DNSZoneCondition) []v1.DNSZoneCondition {
+	now := metav1.NewTime(clock.Now())
+	var additions []v1.DNSZoneCondition
+	for i, update := range updates {
+		add := true
+		for j, cond := range conditions {
+			if cond.Type == update.Type {
+				add = false
+				if conditionChanged(cond, update) {
+					conditions[j].Status = update.Status
+					conditions[j].Reason = update.Reason
+					conditions[j].Message = update.Message
+					conditions[j].LastTransitionTime = now
+					break
+				}
+			}
+		}
+		if add {
+			updates[i].LastTransitionTime = now
+			additions = append(additions, updates[i])
+		}
+	}
+	conditions = append(conditions, additions...)
+	return conditions
+}
+
+func conditionChanged(a, b v1.DNSZoneCondition) bool {
+	return a.Status != b.Status || a.Reason != b.Reason || a.Message != b.Message
+}
+
+// dnsZoneStatusSlicesEqual compares two DNSZoneStatus slice values.  Returns
+// true if the provided values should be considered equal for the purpose of
+// determining whether an update is necessary, false otherwise.  The comparison
+// is agnostic with respect to the ordering of status conditions but not with
+// respect to zones.
+func dnsZoneStatusSlicesEqual(a, b []v1.DNSZoneStatus) bool {
+	conditionCmpOpts := []cmp.Option{
+		cmpopts.EquateEmpty(),
+		cmpopts.SortSlices(func(a, b v1.DNSZoneCondition) bool {
+			return a.Type < b.Type
+		}),
+	}
+	if !cmp.Equal(a, b, conditionCmpOpts...) {
+		return false
+	}
+
+	return true
 }

--- a/pkg/reconciler/dns/dns_record.go
+++ b/pkg/reconciler/dns/dns_record.go
@@ -47,6 +47,10 @@ func (c *Controller) reconcile(ctx context.Context, dnsRecord *v1.DNSRecord) err
 	if !dnsZoneStatusSlicesEqual(statuses, dnsRecord.Status.Zones) {
 		dnsRecord.Status.Zones = statuses
 		dnsRecord.Status.ObservedGeneration = dnsRecord.Generation
+		_, uerr := c.client.KuadrantV1().DNSRecords(dnsRecord.Namespace).UpdateStatus(ctx, dnsRecord, metav1.UpdateOptions{})
+		if uerr != nil {
+			return uerr
+		}
 	}
 	return nil
 }
@@ -200,7 +204,7 @@ func mergeConditions(conditions, updates []v1.DNSZoneCondition) []v1.DNSZoneCond
 }
 
 func conditionChanged(a, b v1.DNSZoneCondition) bool {
-	return a.Status != b.Status || a.Reason != b.Reason || a.Message != b.Message
+	return a.Status != b.Status || a.Reason != b.Reason
 }
 
 // dnsZoneStatusSlicesEqual compares two DNSZoneStatus slice values.  Returns

--- a/pkg/util/slice/slice.go
+++ b/pkg/util/slice/slice.go
@@ -1,0 +1,29 @@
+package slice
+
+// RemoveString returns a newly created []string that contains all items from slice that
+// are not equal to s.
+func RemoveString(slice []string, s string) []string {
+	newSlice := make([]string, 0)
+	for _, item := range slice {
+		if item == s {
+			continue
+		}
+		newSlice = append(newSlice, item)
+	}
+	if len(newSlice) == 0 {
+		// Sanitize for unit tests so we don't need to distinguish empty array
+		// and nil.
+		newSlice = nil
+	}
+	return newSlice
+}
+
+// ContainsString checks if a given slice of strings contains the provided string.
+func ContainsString(slice []string, s string) bool {
+	for _, item := range slice {
+		if item == s {
+			return true
+		}
+	}
+	return false
+}

--- a/samples/dnsrecord.yaml
+++ b/samples/dnsrecord.yaml
@@ -1,0 +1,11 @@
+apiVersion: kuadrant.dev/v1
+kind: DNSRecord
+metadata:
+  name: c833s3fblarnfjtervr0.hcpapps.net
+spec:
+  dnsName: c833s3fblarnfjtervr0.hcpapps.net
+  recordTTL: 60
+  recordType: A
+  targets:
+    - 52.215.108.61
+    - 52.30.101.221

--- a/samples/echo-service-single-cluster/ingress.yaml
+++ b/samples/echo-service-single-cluster/ingress.yaml
@@ -4,7 +4,7 @@ metadata:
   name: ingress-domain
 spec:
   rules:
-    - host: my-hostname.kcp-apps.127.0.0.1.nip.io
+    - host: my-hostname.hcpapps.net
       http:
         paths:
           - path: /


### PR DESCRIPTION
Implements the dns controller to reconcile records into a route53 zone.
Requires the following env vars to be set locally before running the controller:
```
AWS_ACCESS_KEY_ID=<my aws access key id>
AWS_SECRET_ACCESS_KEY=<my aws secret access key>
AWS_DNS_PUBLIC_ZONE_ID=<route53 zone id>
```