### PR TITLE
refactor: Split Ingress reconcile into two methods

### DIFF
--- a/pkg/reconciler/ingress/controller.go
+++ b/pkg/reconciler/ingress/controller.go
@@ -190,7 +190,14 @@ func (c *Controller) process(key string) error {
 	previous := current.DeepCopy()
 
 	ctx := context.TODO()
-	if err := c.reconcile(ctx, current); err != nil {
+
+	rootName, isLeaf := getRootName(current)
+	if isLeaf {
+		err = c.reconcileLeaf(ctx, rootName, current)
+	} else {
+		err = c.reconcileRoot(ctx, current)
+	}
+	if err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Split the Ingress reconciliation method into `reconcileLeaf` and `reconcileRoot`. Add logic to select which method to use based on the Ingress object to be reconciled.